### PR TITLE
add terragrunt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # TerraWiz
 
-TerraWiz is a command-line tool for tracking and analyzing Terraform module usage across GitHub repositories and organizations.
+TerraWiz is a command-line tool for tracking and analyzing Terraform and Terragrunt module usage across GitHub repositories and organizations.
 
 ## Overview
 
-TerraWiz scans GitHub repositories to identify Terraform files and extract information about module usage. It helps teams understand their infrastructure-as-code dependencies, versioning patterns, and module distribution across repositories.
+TerraWiz scans GitHub repositories to identify Terraform and Terragrunt files and extract information about module usage. It helps teams understand their infrastructure-as-code dependencies, versioning patterns, and module distribution across repositories.
 
 ## Installation
 
-### NPM Registry (Once Published)
+### NPM Registry (Soon)
 TBA
 
 ### Local Development Build
@@ -77,6 +77,8 @@ terrawiz scan --org <organization> [options]
 - `--max-repos <number>`: Maximum number of repositories to process
 - `--no-rate-limit`: Disable rate limit protection (enabled by default)
 - `--skip-archived`: Skip archived repositories (default: true)
+- `--terraform-only`: Only scan for Terraform files (default: scan both Terraform and Terragrunt)
+- `--terragrunt-only`: Only scan for Terragrunt files (default: scan both Terraform and Terragrunt)
 
 ## Examples
 
@@ -114,14 +116,24 @@ Scan with debug logging enabled (for troubleshooting):
 terrawiz scan --org myorg --debug
 ```
 
+Search only for Terraform files (excluding Terragrunt):
+```bash
+terrawiz scan --org myorg --terraform-only
+```
+
+Search only for Terragrunt files (excluding Terraform):
+```bash
+terrawiz scan --org myorg --terragrunt-only
+```
+
 ## Output
 
 TerraWiz provides a detailed analysis of Terraform module usage:
 
 ### JSON Format
 Includes structured data with:
-- Metadata (owner, repository, timestamp, counts)
-- Complete module details (source, version, file location, etc.)
+- Metadata (owner, repository, timestamp, counts by file type)
+- Complete module details (source, version, file location, file type, etc.)
 - Summary statistics
 - Rate limit information
 
@@ -129,6 +141,7 @@ Includes structured data with:
 Exports a flat file with columns:
 - module
 - source_type
+- file_type (terraform or terragrunt)
 - version
 - repository
 - file_path
@@ -147,8 +160,10 @@ Displays a human-readable summary with:
 TerraWiz works by:
 1. Retrieving all repositories in an organization or user account
 2. For each repository, getting the file tree from the default branch
-3. Filtering files with .tf extension
-4. Parsing each Terraform file to extract module declarations
+3. Filtering files with .tf extension (Terraform) and terragrunt.hcl files (Terragrunt)
+4. Parsing each file to extract module declarations:
+   - For Terraform files: module blocks with source attributes
+   - For Terragrunt files: terraform blocks with source attributes
 5. Categorizing modules by source type (GitHub, Terraform Registry, local, etc.)
 6. Analyzing version constraints and usage patterns
 
@@ -159,6 +174,7 @@ The tool handles rate limiting for GitHub API results and implements smart throt
 - `src/index.ts`: Main entry point and CLI interface
 - `src/services/github.ts`: GitHub API integration for repository access and file content retrieval
 - `src/parsers/terraform.ts`: Terraform file parsing logic for module extraction
+- `src/parsers/terragrunt.ts`: Terragrunt file parsing logic for module extraction
 - `src/services/logger.ts`: Logging utilities with component-based logging support
 
 ## Notes for Developers
@@ -166,9 +182,14 @@ The tool handles rate limiting for GitHub API results and implements smart throt
 - TerraWiz uses the GitHub API and includes rate limit protection by default
 - The repository tree approach avoids the GitHub search API's 1000 result limit
 - Source types are determined by analyzing the module source string pattern
-- The tool supports various Terraform module source formats including GitHub URLs, Terraform Registry, and local paths
+- The tool supports various module source formats including GitHub URLs, Terraform Registry, and local paths
 - You will need to set up a GITHUB_TOKEN environment variable in a .env file to authenticate with the GitHub API
-- The tool categorizes module sources into types: local, artifactory, archive, registry, or unknown
+- The tool categorizes module sources into types:
+  - For Terraform: local, artifactory, archive, registry, or unknown
+  - For Terragrunt: local, artifactory, archive, registry, git, or unknown
+- Terragrunt files are identified by the extension .hcl and either:
+  - File named exactly "terragrunt.hcl"
+  - Located in a directory with "terragrunt" in the path
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ TerraWiz is a command-line tool for tracking and analyzing Terraform and Terragr
 
 TerraWiz scans GitHub repositories to identify Terraform and Terragrunt files and extract information about module usage. It helps teams understand their infrastructure-as-code dependencies, versioning patterns, and module distribution across repositories.
 
+Key features:
+- Scan entire GitHub organizations or specific repositories
+- Support for both Terraform (.tf) and Terragrunt (terragrunt.hcl) files
+- Detection of various module source types including git, registry, local, and artifactory
+- Version tracking and analysis of module dependencies
+- Flexible output formats (JSON, CSV, table)
+
 ## Installation
 
 ### NPM Registry (Soon)
@@ -173,9 +180,27 @@ The tool handles rate limiting for GitHub API results and implements smart throt
 
 - `src/index.ts`: Main entry point and CLI interface
 - `src/services/github.ts`: GitHub API integration for repository access and file content retrieval
+- `src/parsers/base-parser.ts`: Abstract base class for all IaC parsers with shared logic
 - `src/parsers/terraform.ts`: Terraform file parsing logic for module extraction
 - `src/parsers/terragrunt.ts`: Terragrunt file parsing logic for module extraction
 - `src/services/logger.ts`: Logging utilities with component-based logging support
+
+### Architecture
+
+TerraWiz uses an object-oriented approach with inheritance to promote code reuse:
+
+- `BaseParser<T>`: Abstract class that provides common parsing functionality
+  - Defines the `IaCModule` interface for standardized module information
+  - Implements shared methods like `parseModules()`, `determineSourceType()`, `extractVersion()`
+  - Handles common module summary generation
+
+- `TerraformParser`: Extends BaseParser for Terraform-specific parsing
+  - Implements Terraform-specific module extraction logic
+
+- `TerragruntParser`: Extends BaseParser for Terragrunt-specific parsing
+  - Implements Terragrunt-specific module extraction logic
+
+This architecture ensures consistent handling of different IaC file types while allowing for format-specific parsing logic.
 
 ## Notes for Developers
 
@@ -185,11 +210,28 @@ The tool handles rate limiting for GitHub API results and implements smart throt
 - The tool supports various module source formats including GitHub URLs, Terraform Registry, and local paths
 - You will need to set up a GITHUB_TOKEN environment variable in a .env file to authenticate with the GitHub API
 - The tool categorizes module sources into types:
-  - For Terraform: local, artifactory, archive, registry, or unknown
-  - For Terragrunt: local, artifactory, archive, registry, git, or unknown
+  - local: Local module references (e.g., "./modules/vpc")
+  - artifactory: Modules hosted in Artifactory (contains "jfrog.io")
+  - archive: Archive files (ends with .tar.gz or .zip)
+  - registry: Terraform Registry modules (e.g., "terraform-aws-modules/vpc/aws")
+  - git: Git repositories (prefixed with "git::" or containing "github.com"/"gitlab.com")
+  - unknown: Any other source format
 - Terragrunt files are identified by the extension .hcl and either:
   - File named exactly "terragrunt.hcl"
   - Located in a directory with "terragrunt" in the path
+
+## Contributing
+
+Contributions to TerraWiz are welcome! Here's how to get started:
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Make your changes
+4. Commit your changes (`git commit -m 'Add some amazing feature'`)
+5. Push to the branch (`git push origin feature/amazing-feature`)
+6. Open a Pull Request
+
+Please ensure your code follows the existing style patterns and includes appropriate documentation.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -13,13 +13,16 @@
   },
   "keywords": [
     "terraform",
+    "terragrunt",
     "github",
     "modules",
-    "tracking"
+    "tracking",
+    "iac",
+    "infrastructure-as-code"
   ],
-  "author": "",
+  "author": "Mansour Kheffache",
   "license": "MIT",
-  "description": "A tool to track Terraform modules used in GitHub repositories",
+  "description": "A tool to track and analyze Terraform and Terragrunt modules used in GitHub repositories",
   "dependencies": {
     "@octokit/core": "^6.1.5",
     "@octokit/plugin-throttling": "^10.0.0",

--- a/src/parsers/base-parser.ts
+++ b/src/parsers/base-parser.ts
@@ -1,0 +1,143 @@
+import { IacFile } from '../services/github';
+import { Logger } from '../services/logger';
+
+/**
+ * Common source types for Infrastructure as Code modules
+ */
+export type SourceType = 'local' | 'artifactory' | 'archive' | 'registry' | 'git' | 'unknown';
+
+/**
+ * Base Module interface that defines common properties
+ */
+export interface IaCModule {
+    name: string;
+    source: string;
+    sourceType: SourceType;
+    version?: string;
+    repository: string;
+    filePath: string;
+    fileUrl: string;
+    lineNumber: number;
+    type: string; // 'terraform' or 'terragrunt'
+}
+
+/**
+ * Base parser class that provides common functionality for all IaC parsers
+ */
+export abstract class BaseParser<T extends IaCModule> {
+    protected logger: Logger;
+    protected fileType: string;
+
+    constructor(loggerComponent: string, fileType: string) {
+        this.logger = Logger.forComponent(loggerComponent);
+        this.fileType = fileType;
+    }
+
+    /**
+     * Parse files to extract module information
+     * @param files List of files to parse (will be filtered by type)
+     * @returns Array of extracted modules
+     */
+    parseModules(files: IacFile[]): T[] {
+        // Filter to only include files of the correct type
+        const filteredFiles = files.filter(file => file.type === this.fileType.toLowerCase());
+
+        const modules: T[] = [];
+
+        this.logger.info(`Parsing ${filteredFiles.length} ${this.fileType} files for modules`);
+
+        for (const file of filteredFiles) {
+            try {
+                const fileModules = this.extractModulesFromFile(file);
+                this.logger.debug(`Found ${fileModules.length} modules in ${file.path} (${file.repository})`);
+                modules.push(...fileModules);
+            } catch (error) {
+                this.logger.errorWithStack(`Error parsing file ${file.path} in ${file.repository}`, error as Error);
+            }
+        }
+
+        this.logger.info(`Extracted ${modules.length} modules from all ${this.fileType} files`);
+        return modules;
+    }
+
+    /**
+     * Extract modules from a single file
+     * @param file File to parse
+     * @returns Array of extracted modules from the file
+     */
+    protected abstract extractModulesFromFile(file: IacFile): T[];
+
+    /**
+     * Determine the source type of a module
+     */
+    protected determineSourceType(source: string): SourceType {
+        if (source.startsWith('./') || source.startsWith('../') || source.startsWith('/')) {
+            return 'local';
+        } else if (source.includes('jfrog.io') && !source.endsWith('.tar.gz') && !source.endsWith('.zip')) {
+            return 'artifactory';
+        } else if (source.endsWith('.tar.gz') || source.endsWith('.zip') ||
+            (source.includes('jfrog.io') && (source.includes('.tar.gz') || source.includes('.zip')))) {
+            return 'archive';
+        } else if (source.match(/^[^\/]+\/[^\/]+\/[^\/]+$/) || source.includes('terraform-aws-modules')) {
+            // Format like terraform-aws-modules/rds/aws or similar pattern
+            return 'registry';
+        } else if (source.includes('git::') || source.includes('github.com') || source.includes('gitlab.com')) {
+            return 'git';
+        } else {
+            return 'unknown';
+        }
+    }
+
+    /**
+     * Extract version from different formats
+     * Handles explicit version attributes and embedded versions in git sources
+     */
+    protected extractVersion(source: string, versionAttribute?: string): string | undefined {
+        // First check for explicit version attribute if provided
+        if (versionAttribute) {
+            return versionAttribute;
+        }
+
+        // Then check for git ref pattern
+        const refMatch = source.match(/\?ref=([^&]+)/);
+        if (refMatch) {
+            return refMatch[1];
+        }
+
+        return undefined;
+    }
+
+    /**
+     * Group modules by source to create a summary report
+     * @param modules List of modules to summarize
+     * @returns Object with sources as keys and usage statistics as values
+     */
+    createModuleSummary(modules: T[]): Record<string, { count: number, versions: Record<string, number> }> {
+        this.logger.info(`Creating summary for ${modules.length} modules`);
+        const summary: Record<string, { count: number, versions: Record<string, number> }> = {};
+
+        for (const module of modules) {
+            if (!summary[module.source]) {
+                summary[module.source] = {
+                    count: 0,
+                    versions: {}
+                };
+            }
+
+            summary[module.source].count++;
+
+            if (module.version) {
+                if (!summary[module.source].versions[module.version]) {
+                    summary[module.source].versions[module.version] = 0;
+                }
+                summary[module.source].versions[module.version]++;
+            }
+        }
+
+        const sourceCount = Object.keys(summary).length;
+        const versionedCount = Object.values(summary).filter(s => Object.keys(s.versions).length > 0).length;
+        this.logger.debug(`Summary contains ${sourceCount} unique module sources, ${versionedCount} with version constraints`);
+
+        return summary;
+    }
+}

--- a/src/parsers/terraform.ts
+++ b/src/parsers/terraform.ts
@@ -1,57 +1,28 @@
-import { TerraformFile } from '../services/github';
+import { IacFile } from '../services/github';
+import { BaseParser, IaCModule, SourceType } from './base-parser';
 import { Logger } from '../services/logger';
 
-export interface TerraformModule {
-    name: string;
-    source: string;
-    sourceType: 'local' | 'artifactory' | 'archive' | 'registry' | 'unknown';
-    version?: string;
-    repository: string;
-    filePath: string;
-    fileUrl: string;
-    lineNumber: number;
+/**
+ * Terraform module information
+ */
+export interface TerraformModule extends IaCModule {
+    type: 'terraform';
 }
 
 /**
  * Parser for Terraform files to extract module information
  */
-export class TerraformParser {
-    private logger: Logger;
-
+export class TerraformParser extends BaseParser<TerraformModule> {
     constructor() {
-        this.logger = Logger.forComponent('Parser');
+        super('TerraformParser', 'terraform');
     }
 
     /**
-     * Parse Terraform files to extract module information
-     * @param files List of Terraform files to parse
-     * @returns Array of extracted modules
-     */
-    parseModules(files: TerraformFile[]): TerraformModule[] {
-        const modules: TerraformModule[] = [];
-
-        this.logger.info(`Parsing ${files.length} Terraform files for modules`);
-
-        for (const file of files) {
-            try {
-                const fileModules = this.extractModulesFromFile(file);
-                this.logger.debug(`Found ${fileModules.length} modules in ${file.path} (${file.repository})`);
-                modules.push(...fileModules);
-            } catch (error) {
-                this.logger.errorWithStack(`Error parsing file ${file.path} in ${file.repository}`, error as Error);
-            }
-        }
-
-        this.logger.info(`Extracted ${modules.length} modules from all files`);
-        return modules;
-    }
-
-    /**
-     * Extract modules from a single Terraform file
-     * @param file Terraform file to parse
-     * @returns Array of extracted modules from the file
-     */
-    private extractModulesFromFile(file: TerraformFile): TerraformModule[] {
+ * Extract modules from a single Terraform file
+ * @param file Terraform file to parse
+ * @returns Array of extracted modules from the file
+ */
+    protected extractModulesFromFile(file: IacFile): TerraformModule[] {
         const modules: TerraformModule[] = [];
         const content = file.content;
 
@@ -78,29 +49,13 @@ export class TerraformParser {
 
             const source = sourceMatch[1];
 
-            // Determine source type based on patterns observed in the data
-            let sourceType: 'local' | 'artifactory' | 'archive' | 'registry' | 'unknown';
+            // Determine source type using the base class method
+            const sourceType = this.determineSourceType(source);
 
-            if (source.startsWith('./') || source.startsWith('../')) {
-                sourceType = 'local';
-            } else if (source.includes('jfrog.io') && !source.endsWith('.tar.gz') && !source.endsWith('.zip')) {
-                sourceType = 'artifactory';
-            } else if (source.endsWith('.tar.gz') || source.endsWith('.zip') ||
-                (source.includes('jfrog.io') && (source.includes('.tar.gz') || source.includes('.zip')))) {
-                sourceType = 'archive';
-            } else if (source.match(/^[^\/]+\/[^\/]+\/[^\/]+$/) || source.includes('terraform-aws-modules')) {
-                // Format like terraform-aws-modules/rds/aws or similar pattern
-                sourceType = 'registry';
-            } else {
-                sourceType = 'unknown';
-            }
-
-            // Extract version if available
-            let version: string | undefined;
+            // Extract version from both explicit version attribute and source
             const versionMatch = moduleBlock.match(/version\s*=\s*"([^"]+)"/);
-            if (versionMatch) {
-                version = versionMatch[1];
-            }
+            const versionValue = versionMatch ? versionMatch[1] : undefined;
+            const version = this.extractVersion(source, versionValue);
 
             modules.push({
                 name: moduleName,
@@ -110,44 +65,13 @@ export class TerraformParser {
                 repository: file.repository,
                 filePath: file.path,
                 fileUrl: file.url,
-                lineNumber
+                lineNumber,
+                type: 'terraform'
             });
         }
 
         return modules;
     }
 
-    /**
-     * Group modules by source to create a summary report
-     * @param modules List of modules to summarize
-     * @returns Object with sources as keys and usage statistics as values
-     */
-    createModuleSummary(modules: TerraformModule[]): Record<string, { count: number, versions: Record<string, number> }> {
-        this.logger.info(`Creating summary for ${modules.length} modules`);
-        const summary: Record<string, { count: number, versions: Record<string, number> }> = {};
-
-        for (const module of modules) {
-            if (!summary[module.source]) {
-                summary[module.source] = {
-                    count: 0,
-                    versions: {}
-                };
-            }
-
-            summary[module.source].count++;
-
-            if (module.version) {
-                if (!summary[module.source].versions[module.version]) {
-                    summary[module.source].versions[module.version] = 0;
-                }
-                summary[module.source].versions[module.version]++;
-            }
-        }
-
-        const sourceCount = Object.keys(summary).length;
-        const versionedCount = Object.values(summary).filter(s => Object.keys(s.versions).length > 0).length;
-        this.logger.debug(`Summary contains ${sourceCount} unique module sources, ${versionedCount} with version constraints`);
-
-        return summary;
-    }
+    // createModuleSummary is now provided by BaseParser
 }

--- a/src/parsers/terragrunt.ts
+++ b/src/parsers/terragrunt.ts
@@ -1,0 +1,90 @@
+import { IacFile } from '../services/github';
+import { Logger } from '../services/logger';
+import { BaseParser, IaCModule, SourceType } from './base-parser';
+
+/**
+ * Terragrunt module information
+ */
+export interface TerragruntModule extends IaCModule {
+    type: 'terragrunt';
+}
+
+/**
+ * Parser for Terragrunt files to extract module information
+ */
+export class TerragruntParser extends BaseParser<TerragruntModule> {
+    constructor() {
+        super('TerragruntParser', 'terragrunt');
+    }
+
+    /**
+     * Extract modules from a single Terragrunt file
+     * @param file Terragrunt file to parse
+     * @returns Array of extracted modules from the file
+     */
+    protected extractModulesFromFile(file: IacFile): TerragruntModule[] {
+        const modules: TerragruntModule[] = [];
+        const content = file.content;
+
+        // Regular expression to match terraform blocks with source (terragrunt modules)
+        // Note that Terragrunt uses terraform { source = "..." } pattern
+        const terraformBlockRegex = /terraform\s*{([\s\S]*?)}/g;
+        let blockMatch;
+
+        while ((blockMatch = terraformBlockRegex.exec(content)) !== null) {
+            const blockContent = blockMatch[1];
+
+            // Calculate line number by counting newlines before this match
+            const matchStartPosition = blockMatch.index;
+            const contentBeforeMatch = content.substring(0, matchStartPosition);
+            const lineNumber = (contentBeforeMatch.match(/\n/g) || []).length + 1;
+
+            // Extract source
+            const sourceMatch = blockContent.match(/source\s*=\s*"([^"]+)"/);
+            if (!sourceMatch) {
+                this.logger.debug(`Terraform block in ${file.path} has no source - skipping`);
+                continue;
+            }
+
+            const source = sourceMatch[1];
+            const name = this.extractModuleName(file.path, source);
+
+            // Determine source type using base class method
+            const sourceType = this.determineSourceType(source);
+
+            // Extract version using base class method
+            const version = this.extractVersion(source);
+
+            modules.push({
+                name,
+                source,
+                sourceType,
+                version,
+                repository: file.repository,
+                filePath: file.path,
+                fileUrl: file.url,
+                lineNumber,
+                type: 'terragrunt'
+            });
+        }
+
+        return modules;
+    }
+
+    /**
+     * Extract a module name from the file path or source
+     */
+    private extractModuleName(filePath: string, source: string): string {
+        // Try to get the directory name from the file path
+        const dirMatch = filePath.match(/.*\/([^\/]+)\/terragrunt\.hcl$/);
+        if (dirMatch && dirMatch[1]) {
+            return dirMatch[1];
+        }
+
+        // If not found, derive from source
+        const sourceMatch = source.match(/([^\/]+)$/);
+        return sourceMatch ? sourceMatch[1] : 'unknown';
+    }
+
+    // createModuleSummary is now provided by BaseParser
+}

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -557,42 +557,6 @@ export class GitHubService {
     }
 
     /**
-     * Find all Terraform files using the repository tree approach
-     * @param owner Repository owner or organization name
-     * @param repo Repository name (optional, if searching across an organization)
-     * @param maxRepos Maximum number of repositories to process
-     * @param perPage Number of results per page
-     * @deprecated Use findIacFiles instead and filter by type
-     */
-    async findTerraformFiles(owner: string, repo?: string, maxRepos: number | null = null, perPage: number = 100): Promise<IacFile[]> {
-        // Save current IaC file types setting
-        const originalTypes = [...this.iacFileTypes];
-
-        try {
-            // Temporarily set to only look for Terraform files
-            this.iacFileTypes = ['terraform'];
-
-            // Use the new method
-            const allFiles = await this.findIacFiles(owner, repo, maxRepos, perPage);
-
-            // Convert to legacy TerraformFile type (which should be fine since we only requested terraform files)
-            return allFiles.map(file => ({
-                type: 'terraform' as const,
-                repository: file.repository,
-                path: file.path,
-                content: file.content,
-                url: file.url
-            }));
-        } catch (error) {
-            this.logger.errorWithStack('Error searching for Terraform files', error as Error);
-            throw error;
-        } finally {
-            // Restore original settings
-            this.iacFileTypes = originalTypes;
-        }
-    }
-
-    /**
      * Get content of a file from GitHub
      * @param owner Repository owner
      * @param repo Repository name

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -5,7 +5,16 @@ import { Logger, LogLevel } from './logger';
 
 dotenv.config();
 
-export interface TerraformFile {
+/**
+ * Type of Infrastructure as Code file
+ */
+export type IacFileType = 'terraform' | 'terragrunt';
+
+/**
+ * Represents an Infrastructure as Code file (Terraform or Terragrunt)
+ */
+export interface IacFile {
+    type: IacFileType;
     repository: string;
     path: string;
     content: string;
@@ -70,10 +79,12 @@ export interface GitHubServiceOptions {
     skipArchived?: boolean;
     /** Filter repositories by name using regex pattern */
     repoPattern?: string;
+    /** Types of IaC files to scan for */
+    iacFileTypes?: IacFileType[];
 }
 
 /**
- * Service for interacting with GitHub API to find and process Terraform files
+ * Service for interacting with GitHub API to find and process Infrastructure as Code files
  */
 export class GitHubService {
     private octokit: Octokit;
@@ -85,6 +96,8 @@ export class GitHubService {
     private repoPattern: RegExp | null = null;
     // Track processed repositories to avoid duplicate logs
     private processedRepoCache = new Set<string>();
+    /** Types of IaC files to scan for */
+    private iacFileTypes: IacFileType[] = ['terraform', 'terragrunt'];
 
     /**
      * Create a new GitHubService instance
@@ -100,6 +113,11 @@ export class GitHubService {
 
         this.skipArchived = options.skipArchived !== false; // Default to true
         const useRateLimit = options.useRateLimit !== false; // Default to true
+
+        // Initialize IaC file types to scan (default: both terraform and terragrunt)
+        if (options.iacFileTypes && options.iacFileTypes.length > 0) {
+            this.iacFileTypes = options.iacFileTypes;
+        }
 
         // Initialize repository pattern filter if provided
         if (options.repoPattern) {
@@ -151,7 +169,7 @@ export class GitHubService {
             this.logger.debug('GitHub service initialized without rate limit protection');
         }
 
-        this.logger.debug(`Debug mode: ${isDebugMode}, Skip archived: ${this.skipArchived}, Repo pattern: ${options.repoPattern || 'none'}`);
+        this.logger.debug(`Debug mode: ${isDebugMode}, Skip archived: ${this.skipArchived}, Repo pattern: ${options.repoPattern || 'none'}, IaC file types: ${this.iacFileTypes.join(', ')}`);
     }
 
     /**
@@ -321,12 +339,12 @@ export class GitHubService {
     }
 
     /**
-     * Get all Terraform files in a repository by traversing its tree
+     * Get all IaC files (Terraform and/or Terragrunt) in a repository by traversing its tree
      * @param repoInfo Repository information
      */
-    async getTerraformFilesFromRepo(repoInfo: RepositoryInfo): Promise<TerraformFile[]> {
+    async getIaCFilesFromRepo(repoInfo: RepositoryInfo): Promise<IacFile[]> {
         try {
-            this.logger.info(`Getting Terraform files from ${repoInfo.fullName}...`);
+            this.logger.info(`Getting IaC files from ${repoInfo.fullName}...`);
 
             // Get reference to the default branch
             const reference = await this.octokit.git.getRef({
@@ -354,30 +372,49 @@ export class GitHubService {
                 recursive: '1' // Recursive flag as string '1'
             });
 
-            // Filter for .tf files
-            const terraformFiles: { path: string; url: string; sha: string }[] = tree.data.tree
-                .filter((item: GitHubTreeItem) =>
-                    item.type === 'blob' && item.path && item.path.endsWith('.tf') && item.sha
-                )
+            // Define predicates for different IaC file types
+            const isTerraformFile = (path?: string) => path?.endsWith('.tf');
+            const isTerragruntFile = (path?: string) =>
+                path?.endsWith('.hcl') &&
+                (path.endsWith('terragrunt.hcl') || path.includes('/terragrunt/'));
+
+            // Filter for specified IaC file types
+            const iacFiles: { path: string; url: string; sha: string; type: IacFileType }[] = tree.data.tree
+                .filter((item: GitHubTreeItem) => {
+                    if (item.type !== 'blob' || !item.path || !item.sha) return false;
+
+                    const isTerraform = this.iacFileTypes.includes('terraform') && isTerraformFile(item.path);
+                    const isTerragrunt = this.iacFileTypes.includes('terragrunt') && isTerragruntFile(item.path);
+
+                    return isTerraform || isTerragrunt;
+                })
                 .map((item: GitHubTreeItem) => ({
                     path: item.path as string,
                     url: `https://github.com/${repoInfo.fullName}/blob/${repoInfo.defaultBranch}/${item.path}`,
-                    sha: item.sha as string
+                    sha: item.sha as string,
+                    type: isTerraformFile(item.path as string) ? 'terraform' : 'terragrunt'
                 }));
 
-            if (terraformFiles.length === 0) {
-                this.logger.info(`No Terraform files found in ${repoInfo.fullName}`);
+            // Count files by type
+            const terraformCount = iacFiles.filter(f => f.type === 'terraform').length;
+            const terragruntCount = iacFiles.filter(f => f.type === 'terragrunt').length;
+
+            if (iacFiles.length === 0) {
+                this.logger.info(`No IaC files found in ${repoInfo.fullName}`);
                 return [];
             }
 
-            this.logger.info(`Found ${terraformFiles.length} Terraform files in ${repoInfo.fullName}`);
+            this.logger.info(
+                `Found ${iacFiles.length} IaC files in ${repoInfo.fullName} ` +
+                `(${terraformCount} Terraform, ${terragruntCount} Terragrunt)`
+            );
 
             // Get content for each file
-            const result: TerraformFile[] = [];
+            const result: IacFile[] = [];
             let processedCount = 0;
-            const totalFiles = terraformFiles.length;
+            const totalFiles = iacFiles.length;
 
-            for (const file of terraformFiles) {
+            for (const file of iacFiles) {
                 try {
                     processedCount++;
                     // Show progress every 10 files or at the end
@@ -387,6 +424,7 @@ export class GitHubService {
 
                     const content = await this.getFileContent(repoInfo.owner, repoInfo.name, file.path);
                     result.push({
+                        type: file.type,
                         repository: repoInfo.fullName,
                         path: file.path,
                         content,
@@ -399,19 +437,52 @@ export class GitHubService {
 
             return result;
         } catch (error) {
-            this.logger.errorWithStack(`Error getting Terraform files from ${repoInfo.fullName}`, error as Error);
+            this.logger.errorWithStack(`Error getting IaC files from ${repoInfo.fullName}`, error as Error);
             return [];
         }
     }
 
     /**
-     * Find all Terraform files using the repository tree approach
+     * Get all Terraform files in a repository by traversing its tree
+     * @param repoInfo Repository information
+     * @deprecated Use getIaCFilesFromRepo instead and filter by type
+     */
+    async getTerraformFilesFromRepo(repoInfo: RepositoryInfo): Promise<IacFile[]> {
+        // Save current IaC file types setting
+        const originalTypes = [...this.iacFileTypes];
+
+        try {
+            // Temporarily set to only look for Terraform files
+            this.iacFileTypes = ['terraform'];
+
+            // Use the new method
+            const allFiles = await this.getIaCFilesFromRepo(repoInfo);
+
+            // Convert to legacy TerraformFile type
+            return allFiles.map(file => ({
+                type: 'terraform' as const,
+                repository: file.repository,
+                path: file.path,
+                content: file.content,
+                url: file.url
+            }));
+        } catch (error) {
+            this.logger.errorWithStack(`Error getting Terraform files from ${repoInfo.fullName}`, error as Error);
+            return [];
+        } finally {
+            // Restore original settings
+            this.iacFileTypes = originalTypes;
+        }
+    }
+
+    /**
+     * Find all Infrastructure as Code files using the repository tree approach
      * @param owner Repository owner or organization name
      * @param repo Repository name (optional, if searching across an organization)
      * @param maxRepos Maximum number of repositories to process
      * @param perPage Number of results per page
      */
-    async findTerraformFiles(owner: string, repo?: string, maxRepos: number | null = null, perPage: number = 100): Promise<TerraformFile[]> {
+    async findIacFiles(owner: string, repo?: string, maxRepos: number | null = null, perPage: number = 100): Promise<IacFile[]> {
         try {
             let repositories: RepositoryInfo[] = [];
 
@@ -449,26 +520,75 @@ export class GitHubService {
 
             this.logger.info(`Processing ${repositories.length} repositories...`);
 
-            // Process each repository to get Terraform files
-            const terraformFiles: TerraformFile[] = [];
+            // Process each repository to get Infrastructure as Code files
+            const iacFiles: IacFile[] = [];
             let processedCount = 0;
 
             for (const repository of repositories) {
                 processedCount++;
                 this.logger.info(`Processing repository ${processedCount}/${repositories.length}: ${repository.fullName}`);
 
-                const files = await this.getTerraformFilesFromRepo(repository);
-                terraformFiles.push(...files);
+                const files = await this.getIaCFilesFromRepo(repository);
+                iacFiles.push(...files);
 
                 // Show a summary of our progress so far
-                this.logger.info(`Progress: ${processedCount}/${repositories.length} repositories processed, ${terraformFiles.length} Terraform files found so far`);
+                const terraformCount = iacFiles.filter(f => f.type === 'terraform').length;
+                const terragruntCount = iacFiles.filter(f => f.type === 'terragrunt').length;
+                this.logger.info(
+                    `Progress: ${processedCount}/${repositories.length} repositories processed, ` +
+                    `${iacFiles.length} IaC files found so far ` +
+                    `(${terraformCount} Terraform, ${terragruntCount} Terragrunt)`
+                );
             }
 
-            this.logger.info(`Found a total of ${terraformFiles.length} Terraform files across ${repositories.length} repositories`);
-            return terraformFiles;
+            // Log summary by file type
+            const terraformCount = iacFiles.filter(f => f.type === 'terraform').length;
+            const terragruntCount = iacFiles.filter(f => f.type === 'terragrunt').length;
+            this.logger.info(
+                `Found a total of ${iacFiles.length} Infrastructure as Code files across ${repositories.length} repositories ` +
+                `(${terraformCount} Terraform, ${terragruntCount} Terragrunt)`
+            );
+
+            return iacFiles;
+        } catch (error) {
+            this.logger.errorWithStack('Error searching for Infrastructure as Code files', error as Error);
+            throw error;
+        }
+    }
+
+    /**
+     * Find all Terraform files using the repository tree approach
+     * @param owner Repository owner or organization name
+     * @param repo Repository name (optional, if searching across an organization)
+     * @param maxRepos Maximum number of repositories to process
+     * @param perPage Number of results per page
+     * @deprecated Use findIacFiles instead and filter by type
+     */
+    async findTerraformFiles(owner: string, repo?: string, maxRepos: number | null = null, perPage: number = 100): Promise<IacFile[]> {
+        // Save current IaC file types setting
+        const originalTypes = [...this.iacFileTypes];
+
+        try {
+            // Temporarily set to only look for Terraform files
+            this.iacFileTypes = ['terraform'];
+
+            // Use the new method
+            const allFiles = await this.findIacFiles(owner, repo, maxRepos, perPage);
+
+            // Convert to legacy TerraformFile type (which should be fine since we only requested terraform files)
+            return allFiles.map(file => ({
+                type: 'terraform' as const,
+                repository: file.repository,
+                path: file.path,
+                content: file.content,
+                url: file.url
+            }));
         } catch (error) {
             this.logger.errorWithStack('Error searching for Terraform files', error as Error);
             throw error;
+        } finally {
+            // Restore original settings
+            this.iacFileTypes = originalTypes;
         }
     }
 


### PR DESCRIPTION
- Introduces Terragrunt support (i.e. `terraform` modules in `.hcl` files)
- Refactor the Terraform parser to abstract base functions to be shared with Terragrunt
- A few minor QoL improvements